### PR TITLE
feature: PG gone-away logic tied to SQLSTATE-based policy (requires test coverage)

### DIFF
--- a/src/ConnectionTrait.php
+++ b/src/ConnectionTrait.php
@@ -200,6 +200,46 @@ trait ConnectionTrait
 
     public function canTryAgain(\Throwable $throwable, ?string $sql = null): bool
     {
+        /**
+         * We only retry at statement level for genuine connection/transient errors **outside**
+         * of an active transaction. Two distinct guards are required here, covering different
+         * failure modes:
+         *
+         * - Guard #1 (nesting > 0): runtime view — DBAL currently believes a tx is active.
+         *   In this case we must NOT retry a single statement because:
+         *     (a) If the server-side tx is still alive, a single-statement retry can break
+         *         atomicity/isolation (duplicate effects, reorder writes) and interfere with
+         *         locks/savepoints.
+         *     (b) If the server-side tx has already been lost (network reset/server restart)
+         *         while DBAL still reports nesting > 0, an implicit reconnect would run the
+         *         retried statement outside the original BEGIN (autocommit), causing partial
+         *         writes and/or 25P01/25P02.
+         *   The only exception is the short, controlled window where we are opening the
+         *   first-level transaction (currentlyOpeningFirstLevelTransaction === true): BEGIN
+         *   itself may be retried safely to establish a fresh transactional boundary.
+         */
+        if ($this->getTransactionNestingLevel() > 0 && ! $this->currentlyOpeningFirstLevelTransaction) {
+            return false;
+        }
+
+        /**
+         * - Guard #2 (hasBeenClosedWithAnOpenTransaction): historical view — we **know** this
+         *   connection was explicitly closed while a tx was open (the flag is set in close()
+         *   when nesting > 0). This implies the server-side tx was rolled back and all session
+         *   state (savepoints, locks, SET LOCAL, temp tables) was lost.
+         *
+         *   Even if nesting is now 0 after a reconnect, immediately retrying a single statement
+         *   would run it in autocommit before a fresh BEGIN is established, risking partial
+         *   writes and inconsistent side effects. Therefore we also block statement-level retry
+         *   in this historical condition **until** we are explicitly opening the first-level
+         *   transaction again (currentlyOpeningFirstLevelTransaction === true).
+         *
+         *   In short:
+         *   - Guard #1 protects while DBAL *currently* thinks a tx is active.
+         *   - Guard #2 protects *after* an improper close occurred in the middle of a tx,
+         *     until a clean BEGIN is being (re)opened.
+         *   Both are necessary and complementary.
+         */
         if ($this->hasBeenClosedWithAnOpenTransaction && ! $this->currentlyOpeningFirstLevelTransaction) {
             return false;
         }

--- a/src/Detector/PostgreSQLGoneAwayDetector.php
+++ b/src/Detector/PostgreSQLGoneAwayDetector.php
@@ -18,8 +18,37 @@ class PostgreSQLGoneAwayDetector implements GoneAwayDetector
 
     public function isGoneAwayException(\Throwable $exception, ?string $sql = null): bool
     {
+        // Do NOT retry savepoints
         if ($this->isSavepoint($sql)) {
             return false;
+        }
+
+        // If exception exposes SQLSTATE, do not retry invalid tx state
+        // @see https://www.postgresql.org/docs/current/errcodes-appendix.html
+        if (method_exists($exception, 'getSQLState')) {
+            $state = $exception->getSQLState();
+
+            // 25P01 = "no active SQL transaction" (e.g., SAVEPOINT outside BEGIN)
+            // 25P02 = "in failed SQL transaction" (tx aborted; commands ignored until ROLLBACK)
+            // Reconnecting/retrying won't fix state errors
+            if ($state === '25P01' || $state === '25P02') {
+                return false;
+            }
+
+            // Retry genuine connection failures (class 08)
+            if (is_string($state) && str_starts_with($state, '08')) {
+                return true;
+            }
+
+            // Retry server shutdown / cannot connect now – transient conditions
+            if (in_array($state, ['57P01', '57P02', '57P03'], true)) {
+                return true;
+            }
+
+            // (Optional) Retry too many connections (environment-dependent)
+            // if ($state === '53300') {
+            //     return true;
+            // }
         }
 
         if ($this->isUpdateQuery($sql)) {
@@ -46,9 +75,17 @@ class PostgreSQLGoneAwayDetector implements GoneAwayDetector
 
     /**
      * @see \Doctrine\DBAL\Platforms\AbstractPlatform::createSavePoint
+     * * Also cover RELEASE and ROLLBACK TO SAVEPOINT.
      */
     private function isSavepoint(?string $sql): bool
     {
-        return str_starts_with(trim((string) $sql), 'SAVEPOINT');
+        if ($sql === null) {
+            return false;
+        }
+        $s = ltrim($sql);
+        return (bool) preg_match(
+            '/^(SAVEPOINT|RELEASE\s+SAVEPOINT|ROLLBACK\s+TO\s+SAVEPOINT)\b/i',
+            $s
+        );
     }
 }

--- a/src/Detector/PostgreSQLGoneAwayDetector.php
+++ b/src/Detector/PostgreSQLGoneAwayDetector.php
@@ -23,8 +23,13 @@ class PostgreSQLGoneAwayDetector implements GoneAwayDetector
             return false;
         }
 
-        // If exception exposes SQLSTATE, do not retry invalid tx state
-        // @see https://www.postgresql.org/docs/current/errcodes-appendix.html
+         /*
+         * Prefer authoritative SQLSTATE over message heuristics.
+         * SQLSTATE is stable and portable (Appendix A); messages vary by version, locale, and wrappers.
+         * When available, branch on SQLSTATE; only fallback to tight
+         * message needles if SQLSTATE is missing or inconclusive.
+         * @see https://www.postgresql.org/docs/current/errcodes-appendix.html
+         */
         if (method_exists($exception, 'getSQLState')) {
             $state = $exception->getSQLState();
 
@@ -35,12 +40,18 @@ class PostgreSQLGoneAwayDetector implements GoneAwayDetector
                 return false;
             }
 
-            // Retry genuine connection failures (class 08)
+            // Genuine connection failures → allow statement-level retry (caller must still
+            // ensure there is no active tx before actually retrying):
+            // - Class 08*** = connection exception (lost/failed connections)
             if (is_string($state) && str_starts_with($state, '08')) {
                 return true;
             }
 
-            // Retry server shutdown / cannot connect now – transient conditions
+            // Server transient conditions related to shutdown/availability:
+            // - 57P01 = admin_shutdown
+            // - 57P02 = crash_shutdown
+            // - 57P03 = cannot_connect_now
+            // These are typically safe to retry at statement level (again, only outside a tx).
             if (in_array($state, ['57P01', '57P02', '57P03'], true)) {
                 return true;
             }


### PR DESCRIPTION
Proposal to the reported issue (SQL error 25P01) on: https://syntage.sentry.io/issues/6792267371/?alert_rule_id=864103&alert_type=issue&notification_uuid=563fa10b-e59b-4e3a-88fd-39a74a25cfb1&project=1773787&referrer=slack

DO NOT MERGE IT - REQUIRES TESTS COVERAGE