### PR TITLE
fix: retry mechanism in statement

### DIFF
--- a/src/ConnectionTrait.php
+++ b/src/ConnectionTrait.php
@@ -110,7 +110,7 @@ trait ConnectionTrait
      *
      * @return R
      */
-    private function doWithRetry(callable $callable, ?string $sql = null)
+    public function doWithRetry(callable $callable, ?string $sql = null)
     {
         $backoff = (new Backoff())
             ->setMaxAttempts($this->maxReconnectAttempts)

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -85,21 +85,23 @@ class Statement extends \Doctrine\DBAL\Statement
      */
     private function executeWithRetry(callable $callable, ...$params)
     {
-        try {
-            attempt:
-            $result = $callable(...$params);
-        } catch (Exception $e) {
-            if (! $this->retriableConnection->canTryAgain($e, $this->sql)) {
-                throw $e;
-            }
+        $parentCall = \Closure::fromCallable($callable);
+        $parentCall->bindTo($this, parent::class);
 
-            $this->retriableConnection->increaseAttemptCount();
-            $this->recreateStatement();
-
-            goto attempt;
-        }
-
-        /** @psalm-suppress PossiblyUndefinedVariable */
-        return $result;
+        // Delegate to the connection’s retry mechanism
+        return $this->retriableConnection->doWithRetry(
+            function () use ($parentCall, $params) {
+                try {
+                    // Invoke the underlying parent method
+                    return $parentCall(...$params);
+                } catch (Exception $e) {
+                    // On failure, recreate the statement and rethrow to trigger retry
+                    $this->recreateStatement();
+                    throw $e;
+                }
+            },
+            $this->sql
+        );
     }
 }
+


### PR DESCRIPTION
Same approach applied to 2.x branch on: https://github.com/nesl247/doctrine-mysql-come-back/pull/1 (cherry picked)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized retry handling for database operations, ensuring consistent behavior across statement execution.
* **Bug Fixes**
  * Reduced intermittent failures during query execution by leveraging a unified retry mechanism, improving reliability under transient errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->