### PR TITLE
fix: add PostgreSQL recovery conflict retry for read queries

### DIFF
--- a/src/Detector/PostgreSQLGoneAwayDetector.php
+++ b/src/Detector/PostgreSQLGoneAwayDetector.php
@@ -8,6 +8,7 @@ class PostgreSQLGoneAwayDetector implements GoneAwayDetector
     protected array $goneAwayExceptions = [
         'SSL connection has been closed unexpectedly',
         'no connection to the server',
+        'canceling statement due to conflict with recovery',
     ];
 
     /** @var string[] */

--- a/tests/Unit/Detector/PostgreSQLGoneAwayDetectorTest.php
+++ b/tests/Unit/Detector/PostgreSQLGoneAwayDetectorTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Facile\DoctrineMySQLComeBack\Tests\Unit\Detector;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Detector\PostgreSQLGoneAwayDetector;
+use Facile\DoctrineMySQLComeBack\Tests\Unit\BaseUnitTestCase;
+
+class PostgreSQLGoneAwayDetectorTest extends BaseUnitTestCase
+{
+    private const SSL_CLOSED = 'SSL connection has been closed unexpectedly';
+
+    private const NO_CONNECTION = 'no connection to the server';
+
+    private const RECOVERY_CONFLICT = 'SQLSTATE[40001]: Serialization failure: 7 ERROR: canceling statement due to conflict with recovery';
+
+    private const NOT_RETRYABLE_ERROR = 'Unknown error';
+
+    #[DataProvider('isUpdateQueryDataProvider')]
+    public function testIsUpdateQuery(string $query, bool $isUpdate): void
+    {
+        // Use RECOVERY_CONFLICT because it's only in $goneAwayExceptions (not $goneAwayInUpdateExceptions),
+        // so it correctly demonstrates that UPDATE queries are NOT retried for this error type.
+        $error = new \Exception(self::RECOVERY_CONFLICT);
+
+        $goneAwayDetector = new PostgreSQLGoneAwayDetector();
+
+        $this->assertSame(! $isUpdate, $goneAwayDetector->isGoneAwayException($error, $query));
+        $this->assertTrue($goneAwayDetector->isGoneAwayException($error, 'SELECT 1'));
+    }
+
+    #[DataProvider('savepointDataProvider')]
+    public function testSavepointShouldNotBeRetried(string $sql): void
+    {
+        $error = new \Exception(self::SSL_CLOSED);
+
+        $goneAwayDetector = new PostgreSQLGoneAwayDetector();
+
+        $this->assertFalse($goneAwayDetector->isGoneAwayException($error, $sql));
+        $this->assertTrue($goneAwayDetector->isGoneAwayException($error, 'SELECT 1'));
+    }
+
+    #[DataProvider('isGoneAwayExceptionDataProvider')]
+    public function testIsGoneAwayException(string $message, bool $isUpdate, bool $expectedIsGoneAwayException): void
+    {
+        $error = new \Exception($message);
+        $query = $isUpdate ? 'DELETE FROM table1;' : 'SELECT 1;';
+
+        $this->assertSame(
+            $expectedIsGoneAwayException,
+            (new PostgreSQLGoneAwayDetector())->isGoneAwayException($error, $query)
+        );
+    }
+
+    /**
+     * @return array{string, bool}[]
+     */
+    public static function isUpdateQueryDataProvider(): array
+    {
+        return [
+            ['UPDATE ', true],
+            ['DELETE ', true],
+            ['INSERT ', true],
+            ['SELECT ', false],
+            ['select ', false],
+            ["\n\tSELECT\n", false],
+            ['(select ', false],
+            [' (select ', false],
+            [' 
+            (select ', false],
+            [' UPDATE WHERE (SELECT ', true],
+            [' UPDATE WHERE 
+            (select ', true],
+        ];
+    }
+
+    /**
+     * @return array{string}[]
+     */
+    public static function savepointDataProvider(): array
+    {
+        return [
+            ['SAVEPOINT foo'],
+            ['   SAVEPOINT foo'],
+            ['
+            SAVEPOINT foo'],
+        ];
+    }
+
+    /**
+     * @return array{0: string, 1: bool, 2: bool}[]
+     */
+    public static function isGoneAwayExceptionDataProvider(): array
+    {
+        return [
+            // SSL closed - retryable for both read and update
+            [self::SSL_CLOSED, true, true],
+            [self::SSL_CLOSED, false, true],
+            // No connection - retryable for both read and update
+            [self::NO_CONNECTION, true, true],
+            [self::NO_CONNECTION, false, true],
+            // Recovery conflict - retryable for read only, NOT for update
+            [self::RECOVERY_CONFLICT, false, true],
+            [self::RECOVERY_CONFLICT, true, false],
+            // Unknown error - never retryable
+            [self::NOT_RETRYABLE_ERROR, true, false],
+            [self::NOT_RETRYABLE_ERROR, false, false],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

- Add `canceling statement due to conflict with recovery` to `PostgreSQLGoneAwayDetector::$goneAwayExceptions` so read queries on the replica are automatically retried (up to 3 attempts with exponential backoff) when PostgreSQL cancels them due to WAL replay conflicts
- Error is intentionally **not** added to `$goneAwayInUpdateExceptions` — recovery conflicts only occur on read replicas, retrying writes against a replica would be incorrect
- Add comprehensive `PostgreSQLGoneAwayDetectorTest` covering recovery conflict, SSL, no-connection, savepoint, and unknown error scenarios

## Context

We're seeing recurring `SQLSTATE[40001]: Serialization failure: canceling statement due to conflict with recovery` errors in production (tracked as ENG-9361). These occur when the PostgreSQL replica needs to replay WAL records that conflict with in-flight read queries.

The existing `PostgreSQLGoneAwayDetector` only recognizes SSL disconnection and no-connection errors. Adding the recovery conflict message enables the existing retry mechanism (`doWithRetry` in `ConnectionTrait`) to transparently retry these transient failures.

## Testing

- 22 unit tests, 36 assertions — all passing
- Full functional test suite has a pre-existing PHP 8.5 compatibility issue in `PrimaryReadReplicaConnection` (unrelated to this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced PostgreSQL error detection to recognize additional connection loss scenarios.

* **Tests**
  * Added comprehensive unit test coverage for database error detection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->